### PR TITLE
Add zsh4humans

### DIFF
--- a/frameworks/zsh4humans.zsh
+++ b/frameworks/zsh4humans.zsh
@@ -1,0 +1,20 @@
+(
+
+emulate -L zsh -o err_return -o no_unset -o no_aliases
+cd -- $1
+# download zsh4humans v5
+local v=5
+curl -fsSLO https://github.com/romkatv/zsh4humans/archive/refs/heads/v$v.tar.gz
+# copy over .zshenv and .zshrc
+tar -xzf v$v.tar.gz
+cp zsh4humans-$v/{.zshenv,.zshrc} ./
+# create a config for powerlevel10k
+>.p10k.zsh <<<$'POWERLEVEL9K_MODE=ascii\nPOWERLEVEL9K_DISABLE_CONFIGURATION_WIZARD=true'
+# install and load zimfw/git
+sed -i.bak -E 's|^(z4h install [^|]*)|\1 zimfw/git|' .zshrc
+sed -i.bak -E 's|^(z4h load [^|]*)|\1 $Z4H/zimfw/git|' .zshrc
+rm -r v$v.tar.gz zsh4humans-$v .zshrc.bak
+# initialize zsh4humans; this will fail if the current process doesn't have a TTY
+HOME=$PWD zsh -is <<<'exit'
+
+)

--- a/run.zsh
+++ b/run.zsh
@@ -86,7 +86,10 @@ set_up() {
   # source the installer
   print "::group::Setting up ${1} ..."
   {
-    source frameworks/${1}.zsh ${home_dir}
+    if ! source frameworks/${1}.zsh ${home_dir}; then
+      print -P "\n%F{red}::error::Failed to set up ${1}%f"
+      command rm -rf ${home_dir} || return 1
+    fi
   } always {
     print '\n::endgroup::'
   }
@@ -98,6 +101,11 @@ benchmark() {
   local -r timeunit=ms
   local -r timediv=1000
   local i
+  if [[ ! -d $home_dir ]]; then
+    # this framework has failed to set up
+    print "${1},-,-,-,-" | command tee -a ${results_file}
+    return
+  fi
   # warmup
   for i in {1..3}; do time HOME=${home_dir} zsh -ic 'exit'; done &>/dev/null
   # run


### PR DESCRIPTION
The default config of zsh4humans enables comparable functionality to zimfw (prompt, syntax highlighting, autosuggestions, history substring search, completions, etc.), so no customization seems necessary.

Tested:

    docker run -e TERM -it --rm alpine sh -uexc '
      apk add git curl zsh
      cd
      git clone https://github.com/romkatv/zsh-framework-benchmark.git
      cd zsh-framework-benchmark
      zsh -fc "SHLVL=1 source ./run.zsh -f zsh4humans"'

All frameworks:

    docker run -e TERM -it --rm alpine sh -uexc '
      apk add git curl zsh perl ncurses
      cd
      git clone https://github.com/romkatv/zsh-framework-benchmark.git
      cd zsh-framework-benchmark
      zsh -fc "SHLVL=1 source ./run.zsh"'