### PR TITLE
disable automatic start of tmux in zsh4humans

### DIFF
--- a/frameworks/zsh4humans.zsh
+++ b/frameworks/zsh4humans.zsh
@@ -10,6 +10,10 @@ tar -xzf v${v}.tar.gz
 cp zsh4humans-${v}/{.zshenv,.zshrc} ./
 # create a config for powerlevel10k
 >.p10k.zsh <<<$'POWERLEVEL9K_MODE=ascii\nPOWERLEVEL9K_DISABLE_CONFIGURATION_WIZARD=true'
+# disable automatic start of tmux
+sed -i.bak -E '1i\
+zstyle :z4h: start-tmux no
+' .zshrc
 # install and load zimfw/git
 sed -i.bak -E 's|^(z4h install [^|]*)|\1 zimfw/git|' .zshrc
 sed -i.bak -E 's|^(z4h load [^|]*)|\1 $Z4H/zimfw/git|' .zshrc


### PR DESCRIPTION
None of the other configs enable this feature.

Tested:

```zsh
docker run -e TERM --rm alpine sh -uexc '
  apk add git curl zsh
  cd
  git clone -b z4h-no-tmux https://github.com/romkatv/zsh-framework-benchmark.git
  cd zsh-framework-benchmark
  zsh -fc "SHLVL=1 source ./run.zsh -f zsh4humans"'
```